### PR TITLE
Potential fix for code scanning alert no. 167: Log entries created from user input

### DIFF
--- a/Controllers/LoginController.cs
+++ b/Controllers/LoginController.cs
@@ -306,6 +306,8 @@ namespace HDFCMSILWebMVC.Controllers
         private string MaskUsername(string username)
         {
             if (string.IsNullOrEmpty(username)) return "UnknownUser";
+            // Sanitize input by removing newline characters and other potentially harmful characters
+            username = username.Replace("\r", "").Replace("\n", "").Replace("\t", "");
             return username.Length <= 5 ? "**" : username.Substring(0, 5) + new string('*', username.Length - 5);
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/167](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/167)

To fix the issue, we need to sanitize the user input before logging it. Since the log entries are plain text, we should remove newline characters and other potentially problematic characters from the `User_Name` field. This can be achieved using `String.Replace` or similar methods to ensure that the input is safe for logging.

The fix involves:
1. Modifying the `MaskUsername` method to sanitize the input by removing newline characters and other potentially harmful characters.
2. Ensuring that the sanitized and masked username is logged instead of the raw input.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
