### PR TITLE
Potential fix for code scanning alert no. 56: SQL query built from user-controlled sources

### DIFF
--- a/Controllers/UpdateInvoice.cs
+++ b/Controllers/UpdateInvoice.cs
@@ -51,7 +51,7 @@ namespace HDFCMSILWebMVC.Controllers
 
                         if (DInvDa.ChkInvoiceNo == true)
                         {
-                            inv = db.Set<DownloadFillInvoice>().FromSqlRaw("EXEC uspDownloadInvoice @Invoice_Number ='" + DInvDa.Invoice_Number + "',@ToInvoiceDate='',@FromInvoiceDate='',@ReportType='',@Flag=1").ToList();
+                            inv = db.Set<DownloadFillInvoice>().FromSqlInterpolated($"EXEC uspDownloadInvoice @Invoice_Number={DInvDa.Invoice_Number}, @ToInvoiceDate='', @FromInvoiceDate='', @ReportType='', @Flag=1").ToList();
 
                         }
                         else if (DInvDa.ChkDate == true && DInvDa.ChkReporttype == true)
@@ -60,20 +60,20 @@ namespace HDFCMSILWebMVC.Controllers
                             var Todate = DInvDa.DateTo;
                             if (DInvDa.RerportType == "Select All")
                             {
-                                inv = db.Set<DownloadFillInvoice>().FromSqlRaw("EXEC uspDownloadInvoice @Invoice_Number = '',@ToInvoiceDate='" + Fromdate + "',@FromInvoiceDate='" + Todate + "',@ReportType='" + DInvDa.RerportType + "',@Flag=6").ToList();
+                                inv = db.Set<DownloadFillInvoice>().FromSqlInterpolated($"EXEC uspDownloadInvoice @Invoice_Number='', @ToInvoiceDate={Fromdate}, @FromInvoiceDate={Todate}, @ReportType={DInvDa.RerportType}, @Flag=6").ToList();
 
 
                             }
                             else if (DInvDa.RerportType == "With Trade Ref.No")
                             {
 
-                                inv = db.Set<DownloadFillInvoice>().FromSqlRaw("EXEC uspDownloadInvoice @Invoice_Number = '',@ToInvoiceDate='" + Fromdate + "',@FromInvoiceDate='" + Todate + "',@ReportType='" + DInvDa.RerportType + "',@Flag=6").ToList();
+                                inv = db.Set<DownloadFillInvoice>().FromSqlInterpolated($"EXEC uspDownloadInvoice @Invoice_Number='', @ToInvoiceDate={Fromdate}, @FromInvoiceDate={Todate}, @ReportType={DInvDa.RerportType}, @Flag=6").ToList();
 
 
                             }
                             else if (DInvDa.RerportType == "Without Trade Ref.No")
                             {
-                                inv = db.Set<DownloadFillInvoice>().FromSqlRaw("EXEC uspDownloadInvoice @Invoice_Number = '',@ToInvoiceDate='" + Fromdate + "',@FromInvoiceDate='" + Todate + "',@ReportType='" + DInvDa.RerportType + "',@Flag=6").ToList();
+                                inv = db.Set<DownloadFillInvoice>().FromSqlInterpolated($"EXEC uspDownloadInvoice @Invoice_Number='', @ToInvoiceDate={Fromdate}, @FromInvoiceDate={Todate}, @ReportType={DInvDa.RerportType}, @Flag=6").ToList();
 
                             }
                         }


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/56](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/56)

To fix the issue, the SQL query construction should be modified to use parameterized queries with `FromSqlInterpolated` or `SqlParameter`. This approach ensures that user input is treated as data rather than executable code, preventing SQL injection.

**Steps to fix:**
1. Replace the `FromSqlRaw` method with `FromSqlInterpolated` or use `SqlParameter` objects to pass user input as parameters to the query.
2. Ensure all user-controlled inputs (`DInvDa.Invoice_Number`, `Fromdate`, `Todate`, `DInvDa.RerportType`) are passed as parameters rather than concatenated into the query string.
3. Update all instances of vulnerable query construction in the `ShowInvoices` method.

**Required changes:**
- Modify the SQL query construction on lines 54, 63, 70, and 76 to use parameterized queries.
- No new dependencies are required, as `FromSqlInterpolated` is part of the existing Entity Framework Core library.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
