### PR TITLE
Potential fix for code scanning alert no. 29: SQL query built from user-controlled sources

### DIFF
--- a/Controllers/CancelationInvoiceAndDOController.cs
+++ b/Controllers/CancelationInvoiceAndDOController.cs
@@ -75,7 +75,7 @@ namespace HDFCMSILWebMVC.Controllers
 
                                 var Fromdate = DInvDa.DateFrom;
                                 var Todate = DInvDa.DateTo;
-                                inv = db.Set<cancellationInvDORetainInv>().FromSqlRaw("EXEC uspcancellationInvoiceDO @ToOrder_date ='" + Todate + "',@FromOrder_date='" + Fromdate + "',@Flag=1").ToList();
+                                inv = db.Set<cancellationInvDORetainInv>().FromSqlInterpolated($"EXEC uspcancellationInvoiceDO @ToOrder_date={Todate}, @FromOrder_date={Fromdate}, @Flag=1").ToList();
 
                                 return View("ShowCancellationInvDORetain", inv);
                                 //ListtoDataTable lsttodt = new ListtoDataTable();


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/29](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/29)

To fix the issue, the SQL query should be rewritten to use parameterized queries with `FromSqlRaw` or `FromSqlInterpolated`. This ensures that user-controlled input is safely passed as parameters, preventing SQL injection.

**Steps to fix:**
1. Replace the string concatenation in the SQL query with parameterized placeholders.
2. Use `FromSqlInterpolated` to safely interpolate the parameters into the query.
3. Ensure that the `Fromdate` and `Todate` values are passed as parameters rather than concatenated into the query string.

**Required changes:**
- Modify the SQL query on line 78 to use `FromSqlInterpolated`.
- Ensure that the `Fromdate` and `Todate` values are safely interpolated into the query.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
