### PR TITLE
Potential fix for code scanning alert no. 51: SQL query built from user-controlled sources

### DIFF
--- a/Controllers/TradeOps_DownloadInvoice.cs
+++ b/Controllers/TradeOps_DownloadInvoice.cs
@@ -120,7 +120,14 @@ namespace HDFCMSILWebMVC.Controllers
 
                         if (DInvDa.ChkInvoiceNo == true)
                         {
-                            inv = db.Set<DownloadFillInvoice>().FromSqlRaw("EXEC uspDownloadInvoice @Invoice_Number ='" + DInvDa.Invoice_Number + "',@ToInvoiceDate='',@FromInvoiceDate='',@ReportType='',@Flag=1").ToList();
+                            inv = db.Set<DownloadFillInvoice>().FromSqlRaw(
+                                "EXEC uspDownloadInvoice @Invoice_Number, @ToInvoiceDate, @FromInvoiceDate, @ReportType, @Flag",
+                                new SqlParameter("@Invoice_Number", DInvDa.Invoice_Number ?? (object)DBNull.Value),
+                                new SqlParameter("@ToInvoiceDate", DBNull.Value),
+                                new SqlParameter("@FromInvoiceDate", DBNull.Value),
+                                new SqlParameter("@ReportType", DBNull.Value),
+                                new SqlParameter("@Flag", 1)
+                            ).ToList();
 
                         }
                         else if (DInvDa.ChkDate == true)
@@ -129,7 +136,14 @@ namespace HDFCMSILWebMVC.Controllers
                             var Todate = DInvDa.DateTo;
 
 
-                            inv = db.Set<DownloadFillInvoice>().FromSqlRaw("EXEC uspDownloadInvoice @Invoice_Number = '',@ToInvoiceDate='" + Fromdate + "',@FromInvoiceDate='" + Todate + "',@ReportType='',@Flag=2").ToList();
+                            inv = db.Set<DownloadFillInvoice>().FromSqlRaw(
+                                "EXEC uspDownloadInvoice @Invoice_Number, @ToInvoiceDate, @FromInvoiceDate, @ReportType, @Flag",
+                                new SqlParameter("@Invoice_Number", DBNull.Value),
+                                new SqlParameter("@ToInvoiceDate", Fromdate ?? (object)DBNull.Value),
+                                new SqlParameter("@FromInvoiceDate", Todate ?? (object)DBNull.Value),
+                                new SqlParameter("@ReportType", DBNull.Value),
+                                new SqlParameter("@Flag", 2)
+                            ).ToList();
 
 
                         }
@@ -138,7 +152,14 @@ namespace HDFCMSILWebMVC.Controllers
                             if (DInvDa.RerportType == "With Trade Ref.No")
                             {
 
-                                inv = db.Set<DownloadFillInvoice>().FromSqlRaw("EXEC uspDownloadInvoice @Invoice_Number = '',@ToInvoiceDate='',@FromInvoiceDate='',@ReportType='" + DInvDa.RerportType + "',@Flag=3").ToList();
+                                inv = db.Set<DownloadFillInvoice>().FromSqlRaw(
+                                    "EXEC uspDownloadInvoice @Invoice_Number, @ToInvoiceDate, @FromInvoiceDate, @ReportType, @Flag",
+                                    new SqlParameter("@Invoice_Number", DBNull.Value),
+                                    new SqlParameter("@ToInvoiceDate", DBNull.Value),
+                                    new SqlParameter("@FromInvoiceDate", DBNull.Value),
+                                    new SqlParameter("@ReportType", DInvDa.RerportType ?? (object)DBNull.Value),
+                                    new SqlParameter("@Flag", 3)
+                                ).ToList();
 
 
                             }
@@ -155,7 +176,14 @@ namespace HDFCMSILWebMVC.Controllers
                         }
                         else
                         {
-                            inv = db.Set<DownloadFillInvoice>().FromSqlRaw("EXEC uspDownloadInvoice @Invoice_Number = '',@ToInvoiceDate='',@FromInvoiceDate='',@ReportType='',@Flag=4").ToList();
+                            inv = db.Set<DownloadFillInvoice>().FromSqlRaw(
+                                "EXEC uspDownloadInvoice @Invoice_Number, @ToInvoiceDate, @FromInvoiceDate, @ReportType, @Flag",
+                                new SqlParameter("@Invoice_Number", DBNull.Value),
+                                new SqlParameter("@ToInvoiceDate", DBNull.Value),
+                                new SqlParameter("@FromInvoiceDate", DBNull.Value),
+                                new SqlParameter("@ReportType", DBNull.Value),
+                                new SqlParameter("@Flag", 4)
+                            ).ToList();
                         }
                     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/51](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/51)

To fix the issue, we should replace the string concatenation with parameterized queries. The `FromSqlRaw` method supports parameterized queries, which allow us to safely pass user input as parameters to the SQL query. This approach prevents SQL injection by ensuring that user input is treated as data, not executable code.

Specifically:
1. Replace the concatenated SQL query with a parameterized query.
2. Use `SqlParameter` objects to pass user input as parameters to the query.
3. Apply this fix to all instances of `FromSqlRaw` in the provided code snippet.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
