### PR TITLE
Potential fix for code scanning alert no. 47: SQL query built from user-controlled sources

### DIFF
--- a/Controllers/PaymentReportController.cs
+++ b/Controllers/PaymentReportController.cs
@@ -53,14 +53,14 @@ namespace HDFCMSILWebMVC.Controllers
 
                         if (showpay.chkpayrecDate == true)
                         {
-                            ShowCashOps_UploadList = db.Set<ShowCashOps_Upload>().FromSqlRaw("EXEC uspShowCashOps_Upload @ToCash_Ops_Date='" + showpay.StartDate + "',@FromCash_Ops_Date='" + showpay.EndDate + "',@Payment_Status='',@Flag=1").ToList();
+                            ShowCashOps_UploadList = db.Set<ShowCashOps_Upload>().FromSqlInterpolated($"EXEC uspShowCashOps_Upload @ToCash_Ops_Date={showpay.StartDate},@FromCash_Ops_Date={showpay.EndDate},@Payment_Status='',@Flag=1").ToList();
                             ListtoDataTable lsttodt = new ListtoDataTable();
                             dt = lsttodt.ToDataTable(ShowCashOps_UploadList);
 
                         }
                         else if (showpay.Status == true)
                         {
-                            ShowCashOps_UploadList = db.Set<ShowCashOps_Upload>().FromSqlRaw("EXEC uspShowCashOps_Upload @ToCash_Ops_Date='',@FromCash_Ops_Date='',@Payment_Status='" + showpay.ReportType + "',@Flag=2").ToList();
+                            ShowCashOps_UploadList = db.Set<ShowCashOps_Upload>().FromSqlInterpolated($"EXEC uspShowCashOps_Upload @ToCash_Ops_Date='',@FromCash_Ops_Date='',@Payment_Status={showpay.ReportType},@Flag=2").ToList();
                             ListtoDataTable lsttodt = new ListtoDataTable();
                             dt = lsttodt.ToDataTable(ShowCashOps_UploadList);
                         }


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/47](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/47)

To fix the issue, we should replace the string concatenation in the SQL query with parameterized queries. This can be achieved by using `FromSqlInterpolated` or by explicitly adding parameters to the query. Parameterized queries ensure that user input is treated as data rather than executable code, thereby preventing SQL injection.

In this case, we will use `FromSqlInterpolated` to safely include the user-controlled values (`showpay.ReportType`) in the query. This approach is straightforward and aligns with best practices for secure database interaction.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
