### PR TITLE
Potential fix for code scanning alert no. 55: SQL query built from user-controlled sources

### DIFF
--- a/Controllers/UpdateInvoice.cs
+++ b/Controllers/UpdateInvoice.cs
@@ -51,7 +51,7 @@ namespace HDFCMSILWebMVC.Controllers
 
                         if (DInvDa.ChkInvoiceNo == true)
                         {
-                            inv = db.Set<DownloadFillInvoice>().FromSqlRaw("EXEC uspDownloadInvoice @Invoice_Number ='" + DInvDa.Invoice_Number + "',@ToInvoiceDate='',@FromInvoiceDate='',@ReportType='',@Flag=1").ToList();
+                            inv = db.Set<DownloadFillInvoice>().FromSqlInterpolated($"EXEC uspDownloadInvoice @Invoice_Number={DInvDa.Invoice_Number}, @ToInvoiceDate='', @FromInvoiceDate='', @ReportType='', @Flag=1").ToList();
 
                         }
                         else if (DInvDa.ChkDate == true && DInvDa.ChkReporttype == true)
@@ -60,20 +60,20 @@ namespace HDFCMSILWebMVC.Controllers
                             var Todate = DInvDa.DateTo;
                             if (DInvDa.RerportType == "Select All")
                             {
-                                inv = db.Set<DownloadFillInvoice>().FromSqlRaw("EXEC uspDownloadInvoice @Invoice_Number = '',@ToInvoiceDate='" + Fromdate + "',@FromInvoiceDate='" + Todate + "',@ReportType='" + DInvDa.RerportType + "',@Flag=6").ToList();
+                                inv = db.Set<DownloadFillInvoice>().FromSqlInterpolated($"EXEC uspDownloadInvoice @Invoice_Number='', @ToInvoiceDate={Fromdate}, @FromInvoiceDate={Todate}, @ReportType={DInvDa.RerportType}, @Flag=6").ToList();
 
 
                             }
                             else if (DInvDa.RerportType == "With Trade Ref.No")
                             {
 
-                                inv = db.Set<DownloadFillInvoice>().FromSqlRaw("EXEC uspDownloadInvoice @Invoice_Number = '',@ToInvoiceDate='" + Fromdate + "',@FromInvoiceDate='" + Todate + "',@ReportType='" + DInvDa.RerportType + "',@Flag=6").ToList();
+                                inv = db.Set<DownloadFillInvoice>().FromSqlInterpolated($"EXEC uspDownloadInvoice @Invoice_Number='', @ToInvoiceDate={Fromdate}, @FromInvoiceDate={Todate}, @ReportType={DInvDa.RerportType}, @Flag=6").ToList();
 
 
                             }
                             else if (DInvDa.RerportType == "Without Trade Ref.No")
                             {
-                                inv = db.Set<DownloadFillInvoice>().FromSqlRaw("EXEC uspDownloadInvoice @Invoice_Number = '',@ToInvoiceDate='" + Fromdate + "',@FromInvoiceDate='" + Todate + "',@ReportType='" + DInvDa.RerportType + "',@Flag=6").ToList();
+                                inv = db.Set<DownloadFillInvoice>().FromSqlInterpolated($"EXEC uspDownloadInvoice @Invoice_Number='', @ToInvoiceDate={Fromdate}, @FromInvoiceDate={Todate}, @ReportType={DInvDa.RerportType}, @Flag=6").ToList();
 
                             }
                         }


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/55](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/55)

To fix the problem, the SQL query should be rewritten to use parameterized queries with `FromSqlRaw` or `FromSqlInterpolated`. This ensures that user input is treated as a parameter rather than part of the SQL command, preventing SQL injection. 

The changes involve:
1. Replacing the concatenated SQL query strings with parameterized queries.
2. Using `FromSqlInterpolated` to safely interpolate parameters into the query.
3. Ensuring all user inputs (`DInvDa.Invoice_Number`, `DInvDa.DateFrom`, `DInvDa.DateTo`, `DInvDa.RerportType`) are passed as parameters.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
