### PR TITLE
Potential fix for code scanning alert no. 19: Log entries created from user input

### DIFF
--- a/Controllers/FTPaymentController.cs
+++ b/Controllers/FTPaymentController.cs
@@ -163,7 +163,8 @@ namespace HDFCMSILWebMVC.Controllers
                 DataTable dt = Methods.getDetails("Get_CashOpsDetails", Details[0], Details[1], "", "", "", "", "",_logger);
                 if (dt.Rows.Count > 0)
                 {
-                    _logger.LogError("Duplicate UTR No.: " + Details[11] + " with same  Amount: " + Details[3], "CashOps_Payments", strFileName);
+                    string sanitizedFileName = strFileName.Replace("\n", "").Replace("\r", "");
+                    _logger.LogError("Duplicate UTR No.: " + Details[11] + " with same  Amount: " + Details[3], "CashOps_Payments", sanitizedFileName);
                     return;
                 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/19](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/19)

To fix the issue, we need to sanitize the `strFileName` parameter before logging it. Since the log entries are plain text, we should remove any newline characters or other potentially harmful characters from `strFileName`. This can be achieved using `String.Replace` or a similar method to ensure that the log entry cannot be manipulated.

The fix involves:
1. Sanitizing `strFileName` by replacing newline characters (`\n` and `\r`) with an empty string.
2. Updating the log entry on line 166 to use the sanitized version of `strFileName`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
