### PR TITLE
Potential fix for code scanning alert no. 58: SQL query built from user-controlled sources

### DIFF
--- a/Controllers/UpdateInvoice.cs
+++ b/Controllers/UpdateInvoice.cs
@@ -73,7 +73,12 @@ namespace HDFCMSILWebMVC.Controllers
                             }
                             else if (DInvDa.RerportType == "Without Trade Ref.No")
                             {
-                                inv = db.Set<DownloadFillInvoice>().FromSqlRaw("EXEC uspDownloadInvoice @Invoice_Number = '',@ToInvoiceDate='" + Fromdate + "',@FromInvoiceDate='" + Todate + "',@ReportType='" + DInvDa.RerportType + "',@Flag=6").ToList();
+                                inv = db.Set<DownloadFillInvoice>().FromSqlRaw(
+                                    "EXEC uspDownloadInvoice @Invoice_Number = '', @ToInvoiceDate = @ToDate, @FromInvoiceDate = @FromDate, @ReportType = @ReportType, @Flag = 6",
+                                    new SqlParameter("@ToDate", Fromdate),
+                                    new SqlParameter("@FromDate", Todate),
+                                    new SqlParameter("@ReportType", DInvDa.RerportType)
+                                ).ToList();
 
                             }
                         }


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/58](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/58)

To fix the issue, the SQL query should be refactored to use parameterized queries with `FromSqlRaw` or `FromSqlInterpolated`. This ensures that user input is properly escaped and prevents SQL injection. Specifically:
1. Replace the string concatenation in the `FromSqlRaw` calls with parameterized queries.
2. Use `SqlParameter` objects to pass user input as parameters to the query.
3. Ensure all instances of `FromSqlRaw` in the method are updated to use parameterized queries.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
