### PR TITLE
Potential fix for code scanning alert no. 20: Log entries created from user input

### DIFF
--- a/Controllers/FTPaymentController.cs
+++ b/Controllers/FTPaymentController.cs
@@ -205,7 +205,9 @@ namespace HDFCMSILWebMVC.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex.Message + " For Virtual Account No: " + detailsCash[4] + "" + " and UTR No: " + detailsCash[5] + " ; FTPaymentController;Fill_CashOpsDetails");
+                string sanitizedVirtualAccountNo = detailsCash[4].Replace("\n", "").Replace("\r", "");
+                string sanitizedUTRNo = detailsCash[5].Replace("\n", "").Replace("\r", "");
+                _logger.LogError(ex.Message + " For Virtual Account No: " + sanitizedVirtualAccountNo + " and UTR No: " + sanitizedUTRNo + " ; FTPaymentController;Fill_CashOpsDetails");
                 //clserr.WriteErrorToTxtFile(ex.Message, "FrmPaymentInformation", "Fill_CashOpsDetails");
             }
         }


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/20](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/20)

To fix the issue, we need to sanitize the user-provided values in `detailsCash` before logging them. Since the log entries are plain text, we should remove any newline characters (`\n`, `\r`) from the values to prevent log forging. This can be achieved using `String.Replace` or similar methods. Additionally, we should ensure that the logged values are clearly marked to avoid confusion.

The fix involves modifying the log statement on line 208 to sanitize `detailsCash[4]` and `detailsCash[5]` before concatenating them into the log message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
