### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,9 @@
 
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "IWH-and-MSIL-Audit-Changes" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/5](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions required for the workflow. Based on the provided workflow, it primarily involves checking out the repository, setting up .NET, restoring dependencies, building, and testing. These tasks typically require only `contents: read` permissions. If additional permissions are needed (e.g., for pull requests), they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
