### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/4](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the steps in the workflow, it appears that only `contents: read` is necessary, as the workflow involves checking out the code, restoring dependencies, building, and testing, none of which require write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
