### PR TITLE
Potential fix for code scanning alert no. 175: SQL query built from user-controlled sources

### DIFF
--- a/Controllers/TradeOps_DownloadInvoice.cs
+++ b/Controllers/TradeOps_DownloadInvoice.cs
@@ -166,7 +166,14 @@ namespace HDFCMSILWebMVC.Controllers
                             }
                             else if (DInvDa.RerportType == "Without Trade Ref.No")
                             {
-                                inv = db.Set<DownloadFillInvoice>().FromSqlRaw("EXEC uspDownloadInvoice @Invoice_Number = '',@ToInvoiceDate='',@FromInvoiceDate='',@ReportType='" + DInvDa.RerportType + "',@Flag=3").ToList();
+                                inv = db.Set<DownloadFillInvoice>().FromSqlRaw(
+                                    "EXEC uspDownloadInvoice @Invoice_Number, @ToInvoiceDate, @FromInvoiceDate, @ReportType, @Flag",
+                                    new SqlParameter("@Invoice_Number", DBNull.Value),
+                                    new SqlParameter("@ToInvoiceDate", DBNull.Value),
+                                    new SqlParameter("@FromInvoiceDate", DBNull.Value),
+                                    new SqlParameter("@ReportType", DInvDa.RerportType ?? (object)DBNull.Value),
+                                    new SqlParameter("@Flag", 3)
+                                ).ToList();
 
 
                             }


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/175](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/175)

To fix the issue, the SQL query should be rewritten to use parameterized queries instead of string concatenation. This involves replacing the vulnerable query on line 169 with a properly parameterized query using `FromSqlRaw` and `SqlParameter`. This ensures that user input is treated as data rather than executable code, preventing SQL injection.

**Steps to implement the fix:**
1. Replace the vulnerable query on line 169 with a parameterized query using `FromSqlRaw`.
2. Use `SqlParameter` objects to safely pass user input (`DInvDa.RerportType`) to the query.
3. Ensure all other instances of SQL query construction in the file follow the same secure pattern.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
