### PR TITLE
Potential fix for code scanning alert no. 174: Log entries created from user input

### DIFF
--- a/Controllers/Methods.cs
+++ b/Controllers/Methods.cs
@@ -419,7 +419,7 @@ namespace HDFCMSILWebMVC.Controllers
             {
                 //log enhance by chaitrali 3/7/2024
                 string virtualAccount = details.Length > 8 && details[8].Length >= 22 ? details[8].Substring(0, 22) : "N/A";
-                string utrNumber = details.Length > 11 ? details[11] : "N/A";
+                string utrNumber = details.Length > 11 ? details[11].Replace(Environment.NewLine, "").Replace("\r", "").Replace("\n", "") : "N/A";
 
                 logger.LogError(EX, "Exception in Insert_PaymentUploadDetails. Virtual Account No: {VirtualAccount}, UTR No: {UTR}", virtualAccount, utrNumber);
 


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/174](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/174)

To fix the issue, we need to sanitize the `utrNumber` variable before logging it. Specifically:
1. Remove any newline characters (`\r`, `\n`) from the `utrNumber` to prevent log forgery in plain text logs.
2. Ensure that the `utrNumber` is properly encoded if the logs are displayed in an HTML context (though this is not explicitly mentioned in the provided code).

The fix will involve replacing the assignment of `utrNumber` with a sanitized version that removes newline characters using `Replace`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
