### PR TITLE
Potential fix for code scanning alert no. 31: SQL query built from user-controlled sources

### DIFF
--- a/Controllers/CancelationInvoiceAndDOController.cs
+++ b/Controllers/CancelationInvoiceAndDOController.cs
@@ -108,7 +108,12 @@ namespace HDFCMSILWebMVC.Controllers
 
                                 var Fromdate = DInvDa.DateFrom;
                                 var Todate = DInvDa.DateTo;
-                                inv2 = db.Set<cancellationoderNoInv>().FromSqlRaw("EXEC uspcancellationInvoiceDO @ToOrder_date ='" + Todate + "',@FromOrder_date='" + Fromdate + "',@Flag=2").ToList();
+                                inv2 = db.Set<cancellationoderNoInv>().FromSqlRaw(
+                                    "EXEC uspcancellationInvoiceDO @ToOrder_date, @FromOrder_date, @Flag",
+                                    new SqlParameter("@ToOrder_date", Todate),
+                                    new SqlParameter("@FromOrder_date", Fromdate),
+                                    new SqlParameter("@Flag", 2)
+                                ).ToList();
 
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/31](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/31)

To fix the issue, the raw SQL query should be parameterized to prevent SQL injection. Instead of concatenating strings to build the query, use placeholders for parameters and supply the values separately. The `FromSqlRaw` method supports parameterized queries, which can be used to safely pass the values of `Todate` and `Fromdate`.

The changes will involve:
1. Modifying the SQL query to use parameter placeholders (`@ToOrder_date` and `@FromOrder_date`) instead of concatenating the values directly.
2. Passing the parameters as a separate array to the `FromSqlRaw` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
