### PR TITLE
Potential fix for code scanning alert no. 36: SQL query built from user-controlled sources

### DIFF
--- a/Controllers/DoInformationController.cs
+++ b/Controllers/DoInformationController.cs
@@ -68,15 +68,15 @@ namespace HDFCMSILWebMVC.Controllers
                 using (var db = new Entities.DatabaseContext())
                 {
                     // Define SQL commands with parameter placeholders
-                    var invoiceQuery = "EXEC SP_GetDetails_Web @Task = 'Get_DoDetailsAsInvoice', @Search1 = '"+do_number+"', @Search2 = '', @Search3 = '', @Search4 =  '', @Search5 =  '', @Search6 =  '', @Search7 =  ''";
-                    var orderQuery = "EXEC SP_GetDetails_Web @Task = 'Get_DoDetailsAsOrder', @Search1 = '" + do_number + "', @Search2 =  '', @Search3 =  '', @Search4 =  '', @Search5 =  '', @Search6 =  '', @Search7 =  ''";
-                    var cashOpsQuery = "EXEC SP_GetDetails_Web @Task = 'Get_DoDetailsAsCashOps', @Search1 = '" + do_number + "', @Search2 =  '', @Search3 =  '', @Search4 =  '', @Search5 =  '', @Search6 =  '', @Search7 =  ''";
-                    var paymentQuery = "EXEC SP_GetDetails_Web @Task = 'Get_DoDetailsAsPayment', @Search1 = '" + do_number + "', @Search2 =  '', @Search3 =  '', @Search4 =  '', @Search5 =  '', @Search6 =  '', @Search7 =  ''";
+                    var invoiceQuery = "EXEC SP_GetDetails_Web @Task = 'Get_DoDetailsAsInvoice', @Search1 = @do_number, @Search2 = '', @Search3 = '', @Search4 =  '', @Search5 =  '', @Search6 =  '', @Search7 =  ''";
+                    var orderQuery = "EXEC SP_GetDetails_Web @Task = 'Get_DoDetailsAsOrder', @Search1 = @do_number, @Search2 =  '', @Search3 =  '', @Search4 =  '', @Search5 =  '', @Search6 =  '', @Search7 =  ''";
+                    var cashOpsQuery = "EXEC SP_GetDetails_Web @Task = 'Get_DoDetailsAsCashOps', @Search1 = @do_number, @Search2 =  '', @Search3 =  '', @Search4 =  '', @Search5 =  '', @Search6 =  '', @Search7 =  ''";
+                    var paymentQuery = "EXEC SP_GetDetails_Web @Task = 'Get_DoDetailsAsPayment', @Search1 = @do_number, @Search2 =  '', @Search3 =  '', @Search4 =  '', @Search5 =  '', @Search6 =  '', @Search7 =  ''";
 
-                    viewModel.Invoicelist = db.Set<InvoiceDetails>().FromSqlRaw(invoiceQuery).ToList();
-                    viewModel.orderlist = db.Set<OrderDetails>().FromSqlRaw(orderQuery).ToList();
-                    viewModel.CashopsList = db.Set<CashOPSDetails>().FromSqlRaw(cashOpsQuery).ToList();
-                    viewModel.PaymentList = db.Set<PaymentDetails>().FromSqlRaw(paymentQuery).ToList();
+                    viewModel.Invoicelist = db.Set<InvoiceDetails>().FromSqlRaw(invoiceQuery, new SqlParameter("@do_number", do_number)).ToList();
+                    viewModel.orderlist = db.Set<OrderDetails>().FromSqlRaw(orderQuery, new SqlParameter("@do_number", do_number)).ToList();
+                    viewModel.CashopsList = db.Set<CashOPSDetails>().FromSqlRaw(cashOpsQuery, new SqlParameter("@do_number", do_number)).ToList();
+                    viewModel.PaymentList = db.Set<PaymentDetails>().FromSqlRaw(paymentQuery, new SqlParameter("@do_number", do_number)).ToList();
 
                 }
             }


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/36](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/36)

To fix the issue, the SQL queries should be rewritten to use parameterized queries with `FromSqlRaw`. This approach ensures that user input is safely passed as parameters, preventing SQL injection. Specifically:
1. Replace the string concatenation in the query construction with parameter placeholders (e.g., `@Search1`).
2. Use `DbContext.Database.ExecuteSqlRaw` or `FromSqlRaw` with parameters to safely pass user input to the query.
3. Ensure that all user input is passed as parameters, even if it has been validated by `CheckForSpecial`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
