### PR TITLE
Potential fix for code scanning alert no. 192: Log entries created from user input

### DIFF
--- a/Controllers/Methods.cs
+++ b/Controllers/Methods.cs
@@ -287,7 +287,8 @@ namespace HDFCMSILWebMVC.Controllers
             {
                 //log enhance by chaitrali 3/7/2024
               
-                string accountno= detailsCash[4].ToString().Length <= 4 ? "****" : new string('*', detailsCash[4].ToString().Length - 4) + detailsCash[4].ToString()[^4..];
+                string sanitizedAccountNo = detailsCash[4]?.Replace(Environment.NewLine, "").Replace("\r", "").Replace("\n", "");
+                string accountno = sanitizedAccountNo.Length <= 4 ? "****" : new string('*', sanitizedAccountNo.Length - 4) + sanitizedAccountNo[^4..];
                 string sanitizedUTR = detailsCash[5].Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
                 var maskedAccount = accountno?.Length > 4 ? "****" + accountno.Substring(accountno.Length - 4): accountno;
                 logger.LogError("Exception occurred: {Message}. VirtualAccount ending: {VirtualAccountMasked}, UTR Present: {UTRPresent}", ex.Message, maskedAccount, !string.IsNullOrWhiteSpace(sanitizedUTR));


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/192](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/192)

To fix the issue, sanitize the user input (`detailsCash[4]`) before using it in the log entry. Specifically:
1. Remove newline characters (`\n`, `\r`, `Environment.NewLine`) from the input to prevent log forging in plain text logs.
2. Optionally, HTML-encode the input if the logs are displayed in an HTML context to prevent HTML injection.

The sanitization should be applied to `detailsCash[4]` before constructing the `maskedAccount` variable. This ensures that the logged data is safe and does not allow malicious manipulation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
