### PR TITLE
Potential fix for code scanning alert no. 190: Log entries created from user input

### DIFF
--- a/Controllers/FTPaymentController.cs
+++ b/Controllers/FTPaymentController.cs
@@ -215,9 +215,11 @@ namespace HDFCMSILWebMVC.Controllers
             }
             catch (Exception ex)
             {
-                // Mask sensitive fields
-                string maskedAccount = detailsCash[4]?.Length >= 4 ? "****" + detailsCash[4][^4..] : "****";
-                string maskedUTR = detailsCash[5]?.Length >= 4 ? "****" + detailsCash[5][^4..] : "****";
+                // Mask sensitive fields and sanitize input
+                string sanitizedAccount = detailsCash[4]?.Replace("\n", "").Replace("\r", "");
+                string sanitizedUTR = detailsCash[5]?.Replace("\n", "").Replace("\r", "");
+                string maskedAccount = sanitizedAccount?.Length >= 4 ? "****" + sanitizedAccount[^4..] : "****";
+                string maskedUTR = sanitizedUTR?.Length >= 4 ? "****" + sanitizedUTR[^4..] : "****";
 
                 // Use structured logging and exception object
                 _logger.LogError(ex, "Exception in Fill_CashOpsDetails (FTPaymentController). Virtual Account: {VirtualAccountMasked}, UTR: {UTRMasked}",  maskedAccount, maskedUTR);


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/190](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/190)

To fix the issue, we need to sanitize the user-provided input (`detailsCash[4]` and `detailsCash[5]`) before logging it. Specifically:
1. Remove any newline characters (`\n`, `\r`) to prevent log forgery.
2. Optionally, HTML-encode the input if the logs are displayed in an HTML-based interface.

The fix will involve:
- Using `String.Replace` to remove newline characters from `detailsCash[4]` and `detailsCash[5]` before constructing `maskedAccount` and `maskedUTR`.
- Ensuring that the sanitized values are used in the log message.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
