### PR TITLE
Potential fix for code scanning alert no. 178: Log entries created from user input

### DIFF
--- a/Controllers/Methods.cs
+++ b/Controllers/Methods.cs
@@ -598,7 +598,8 @@ namespace HDFCMSILWebMVC.Controllers
             catch (Exception EX)
             {
                 //log enhance by chaitrali 3/7/2024
-                logger.LogError(EX, "Error occurred in getDetails. Task: {Task}, Identifier: {Search1}", Task, Search1);
+                string sanitizedSearch1 = Search1?.Replace(Environment.NewLine, "").Replace("\r", "").Replace("\n", "");
+                logger.LogError(EX, "Error occurred in getDetails. Task: {Task}, Identifier: {Search1}", Task, sanitizedSearch1);
 
                 //logger.LogError(EX.Message + " For Task: " + Task + "" + " and invoiceNo or Do Number or OrderID: " + Search1 + " ; getDetails");
                 return null;


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/178](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/178)

To fix the issue, sanitize the `Search1` parameter before logging it. This involves removing potentially harmful characters, such as line breaks, that could be used to manipulate log entries. The `String.Replace` method can be used to remove newline characters (`\r`, `\n`, and `Environment.NewLine`) from the input.

The fix will be applied in the `catch` block of the `getDetails` method in `Controllers/Methods.cs`. Specifically, the `Search1` parameter will be sanitized before being passed to the logger.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
