### PR TITLE
Potential fix for code scanning alert no. 180: Log entries created from user input

### DIFF
--- a/Controllers/DownloadInvoice.cs
+++ b/Controllers/DownloadInvoice.cs
@@ -52,7 +52,14 @@ namespace HDFCMSILWebMVC.Controllers
                 }
                 try
                 {
-                    _logger.LogError("Filter values - ChkDate: {ChkDate}; ChkInvoiceNo: {ChkInvoiceNo}; ChkReportType: {ChkReportType}; DateFrom: {DateFrom}; DateTo: {DateTo}; Invoice_Number: {InvoiceNumber}; ReportType: {ReportType}", DInvDa.ChkDate, DInvDa.ChkInvoiceNo, DInvDa.ChkReporttype, DInvDa.DateFrom, DInvDa.DateTo, DInvDa.Invoice_Number, DInvDa.RerportType);
+                    _logger.LogError("Filter values - ChkDate: {ChkDate}; ChkInvoiceNo: {ChkInvoiceNo}; ChkReportType: {ChkReportType}; DateFrom: {DateFrom}; DateTo: {DateTo}; Invoice_Number: {InvoiceNumber}; ReportType: {ReportType}", 
+                        SanitizeInput(DInvDa.ChkDate), 
+                        SanitizeInput(DInvDa.ChkInvoiceNo), 
+                        SanitizeInput(DInvDa.ChkReporttype), 
+                        SanitizeInput(DInvDa.DateFrom), 
+                        SanitizeInput(DInvDa.DateTo), 
+                        SanitizeInput(DInvDa.Invoice_Number), 
+                        SanitizeInput(DInvDa.RerportType));
 
                     //_logger.LogError("values of filters ChkDate:" + DInvDa.ChkDate + "; ChkInvoiceNo: " + DInvDa.ChkInvoiceNo + " DateFrom: " + DInvDa.ChkReporttype + ";" + DInvDa.DateFrom + " ; Invoice_Number: " + DInvDa.DateTo + "" + DInvDa.Invoice_Number + " ; RerportType:" + DInvDa.RerportType);
                     using (var db = new Entities.DatabaseContext())
@@ -214,6 +221,13 @@ namespace HDFCMSILWebMVC.Controllers
                 return View(inv);
             }
 
+        }
+
+        private string SanitizeInput(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return input;
+            return input.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
         }
         private string Sanitize(string input)
         {


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/180](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/180)

To fix the issue, sanitize the user-provided values before logging them. Since the log entries are plain text, remove line breaks and other potentially problematic characters from the user input using `String.Replace` or similar methods. This ensures that malicious users cannot inject special characters to forge log entries.

The best approach is to sanitize all user-provided values (`DInvDa.ChkDate`, `DInvDa.ChkInvoiceNo`, `DInvDa.ChkReportType`, `DInvDa.DateFrom`, `DInvDa.DateTo`, `DInvDa.Invoice_Number`, `DInvDa.ReportType`) before logging them. This can be done by creating a helper method to sanitize strings and applying it to each field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
