### PR TITLE
Potential fix for code scanning alert no. 185: Log entries created from user input

### DIFF
--- a/Controllers/FTPaymentController.cs
+++ b/Controllers/FTPaymentController.cs
@@ -172,8 +172,8 @@ namespace HDFCMSILWebMVC.Controllers
                 {
                     string sanitizedFileName = strFileName.Replace("\n", "").Replace("\r", "");
                     string utrMasked = MaskSensitive(Details[11]);  // Show only last 4 if needed
-                    string amount = Details[3];
-                    _logger.LogError("Duplicate UTR detected. UTR: {UTR}, Amount: {Amount}, File: {FileName}",utrMasked, amount, sanitizedFileName);
+                    string amount = Details[3].Replace("\n", "").Replace("\r", "");
+                    _logger.LogError("Duplicate UTR detected. UTR: {UTR}, Amount: {Amount}, File: {FileName}", utrMasked, amount, sanitizedFileName);
                     //_logger.LogError("Duplicate UTR No.: " + Details[11] + " with same  Amount: " + Details[3], "CashOps_Payments", sanitizedFileName);
                     //_logger.LogError("Duplicate UTR No.: " + Details[11] + " with same  Amount: " + Details[3], "CashOps_Payments", strFileName);
                     return;


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/001TN0172/security/code-scanning/185](https://github.com/Byzan-Systems/001TN0172/security/code-scanning/185)

To address the issue, the user-provided value `Details[3]` (assigned to `amount`) should be sanitized before being included in the log entry. Specifically:
1. Remove newline characters (`\n` and `\r`) to prevent log forgery in a plain-text log.
2. Ensure the value is clearly marked to avoid confusion or spoofing in the log entries.
3. If the log entries are displayed in HTML, apply HTML encoding to the value.

The fix involves replacing the line where `amount` is logged with a sanitized version of `amount`. The same sanitization logic used for `strFileName` can be applied here (`Replace("\n", "").Replace("\r", "")`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
